### PR TITLE
Fix Certbot error by ensuring /var/www/certbot directory exists

### DIFF
--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -22,6 +22,7 @@ if [ -d "$CERT_PATH" ]; then
     echo "✅ Zertifikat für $DOMAIN existiert bereits. Überspringe Anforderung."
 else
     echo "📜 Fordere Let's Encrypt Zertifikat an..."
+    mkdir -p /var/www/certbot
     certbot certonly --webroot -w /var/www/certbot -d $DOMAIN --email $EMAIL --agree-tos --no-eff-email --force-renewal
 fi
 


### PR DESCRIPTION
Add a command to create the `/var/www/certbot` directory before running the `certbot certonly` command in `scripts/init-letsencrypt.sh`.

* Add `mkdir -p /var/www/certbot` command to ensure the directory exists before running the `certbot certonly` command.
