### PR TITLE
Fix nginx and certbot dependency loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       - letsencrypt:/etc/letsencrypt
       - certbot-www:/var/www/certbot
     entrypoint: /bin/sh -c "while true; do certbot renew --webroot -w /var/www/certbot && sleep 12h; done"
-    depends_on:
-      - nginx
 
 volumes:
   letsencrypt:

--- a/init.sh
+++ b/init.sh
@@ -56,15 +56,15 @@ sed -i "s/DOMAIN_PLACEHOLDER/$DOMAIN/g" scripts/init-letsencrypt.sh
 sed -i "s/EMAIL_PLACEHOLDER/$EMAIL/g" scripts/init-letsencrypt.sh
 sed -i "s/MY_KEY_PLACEHOLDER/$MY_KEY/g" docker-compose.yml
 
-# 🔹 6. Docker-Compose starten
-echo -e "${GREEN}🚀 Starte Docker-Container...${NC}"
-docker compose up -d
-sleep 10  # Warte auf vollständigen Start
-
-# 🔹 7. SSL-Zertifikat beantragen
+# 🔹 6. SSL-Zertifikat beantragen
 echo -e "${GREEN}🔒 Erstelle Let's Encrypt Zertifikat...${NC}"
 chmod +x scripts/init-letsencrypt.sh
 scripts/init-letsencrypt.sh
+
+# 🔹 7. Docker-Compose starten
+echo -e "${GREEN}🚀 Starte Docker-Container...${NC}"
+docker compose up -d
+sleep 10  # Warte auf vollständigen Start
 
 # 🔹 8. Falls automatische Updates aktiviert wurden, Cronjob einrichten
 if [[ "$AUTO_UPDATE" == "y" ]]; then

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -4,7 +4,6 @@ set -e  # Beende Skript bei Fehlern
 
 DOMAIN=DOMAIN_PLACEHOLDER
 EMAIL=EMAIL_PLACEHOLDER
-WEBROOT_PATH=/var/www/certbot
 CERT_PATH="/etc/letsencrypt/live/$DOMAIN"
 
 echo "🔐 Erstelle Let's Encrypt Zertifikat für $DOMAIN..."
@@ -14,10 +13,7 @@ if [ -d "$CERT_PATH" ]; then
     echo "✅ Zertifikat für $DOMAIN existiert bereits. Überspringe Anforderung."
 else
     echo "📜 Fordere Let's Encrypt Zertifikat an..."
-    mkdir -p "$WEBROOT_PATH"
-    certbot certonly --webroot -w "$WEBROOT_PATH" -d "$DOMAIN" --email "$EMAIL" --agree-tos --no-eff-email --force-renewal
+    certbot certonly --standalone -d "$DOMAIN" --email "$EMAIL" --agree-tos --no-eff-email --force-renewal
 fi
 
 echo "✅ SSL-Zertifikat wurde erfolgreich eingerichtet."
-
-echo "📢 Bitte stelle sicher, dass Nginx für die ACME-Challenge das Verzeichnis $WEBROOT_PATH nutzt."


### PR DESCRIPTION
Update init-script to resolve dependency loop between nginx and Let's Encrypt certificate creation.

* **docker-compose.yml**
  - Remove `depends_on` from `certbot-renew` service.

* **init.sh**
  - Move SSL certificate creation step before starting Docker containers.
  - Update SSL certificate creation step to use the `--standalone` option.

* **scripts/init-letsencrypt.sh**
  - Update Certbot command to use the `--standalone` option.
  - Remove webroot path configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Complexitree/server-init/pull/3?shareId=eb9c3664-8f87-4582-845a-7a5d44a4dba8).