### PR TITLE
Use wget for IPv6-compatible downloads in init-lb

### DIFF
--- a/init-lb.sh
+++ b/init-lb.sh
@@ -96,9 +96,9 @@ echo -e "${GREEN}📅 Lade Konfigurationsdateien von GitHub...${NC}"
 mkdir -p /opt/docker-setup
 cd /opt/docker-setup
 echo "📄 Lade docker-compose.lb.yml..."
-wget -qO docker-compose.lb.yml https://raw.githubusercontent.com/Complexitree/server-init/main/docker-compose.lb.yml
+wget --retry-connrefused --tries=3 -qO docker-compose.lb.yml https://raw.githubusercontent.com/Complexitree/server-init/main/docker-compose.lb.yml || { echo "❌ Fehler beim Herunterladen von docker-compose.lb.yml"; exit 1; }
 echo "📄 Lade nginx-lb.conf..."
-wget -qO nginx-lb.conf https://raw.githubusercontent.com/Complexitree/server-init/main/nginx-lb.conf
+wget --retry-connrefused --tries=3 -qO nginx-lb.conf https://raw.githubusercontent.com/Complexitree/server-init/main/nginx-lb.conf || { echo "❌ Fehler beim Herunterladen von nginx-lb.conf"; exit 1; }
 
 # 🔹 5. Ersetze Platzhalter in `docker-compose.lb.yml` und `nginx-lb.conf`
 cd /opt/docker-setup


### PR DESCRIPTION
## Summary
- install wget for later use
- fetch `docker-compose.lb.yml` and `nginx-lb.conf` via `wget` to avoid git clone in IPv6-only environments

## Testing
- `bash -n init-lb.sh`
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b7f88220708326a17ec91bf619ac0e